### PR TITLE
Added jQuery from the official jQuery CDN

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -49,6 +49,7 @@
     {{ghost_foot}}
 
     {{! The main JavaScript file for Casper }}
+    <script type="text/javascript" src="//code.jquery.com/jquery-2.1.4.min.js"></script>
     <script type="text/javascript" src="/assets/js/index.js"></script>
 
 </body>


### PR DESCRIPTION
Added this as jQuery has been removed from `ghost_foot`.

http://dev.ghost.org/no-more-jquery/
